### PR TITLE
fix: update API URL and enable credentials in API client

### DIFF
--- a/src/config/env.config.ts
+++ b/src/config/env.config.ts
@@ -1,6 +1,6 @@
 export const ENV_CONFIG = {
   API: {
-    URL: import.meta.env.VITE_API_URL || 'http://localhost:1337/api',
+    URL: import.meta.env.VITE_API_URL || 'https://original-melody-94a4138af3.strapiapp.com/api',
     TOKEN: import.meta.env.VITE_API_TOKEN,
     TIMEOUT: Number(import.meta.env.VITE_API_TIMEOUT) || 30000,
   },

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -21,6 +21,7 @@ class ApiClient {
         Authorization: `Bearer ${ENV_CONFIG.API.TOKEN}`,
       },
       timeout: ENV_CONFIG.API.TIMEOUT,
+      withCredentials: true,
     });
 
     this.rateLimiter = new RateLimiter({

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,16 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "Access-Control-Allow-Credentials", "value": "true" },
+        { "key": "Access-Control-Allow-Origin", "value": "https://original-melody-94a4138af3.strapiapp.com" },
+        { "key": "Access-Control-Allow-Methods", "value": "GET,OPTIONS,PATCH,DELETE,POST,PUT" },
+        { "key": "Access-Control-Allow-Headers", "value": "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version, Authorization" }
+      ]
+    }
+  ],
+  "env": {
+    "VITE_API_URL": "https://original-melody-94a4138af3.strapiapp.com/api"
+  }
+} 


### PR DESCRIPTION
- Changed the default API URL to a production endpoint for better integration.
- Added 'withCredentials' option in the API client to support cross-origin requests with credentials.