### PR TITLE
feat: persist bookmarks in Supabase

### DIFF
--- a/src/core/services/bookmarksService.ts
+++ b/src/core/services/bookmarksService.ts
@@ -1,0 +1,166 @@
+import { supabase } from './supabaseClient';
+
+export type BookmarkItemType = 'quote' | 'affirmation';
+
+export interface BookmarkRecord {
+  itemId: string;
+  itemType: BookmarkItemType;
+  title: string;
+  url: string | null;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateBookmarkInput {
+  itemId: string;
+  itemType: BookmarkItemType;
+  title: string;
+  url?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+interface BookmarkRow {
+  item_id: string;
+  item_type: BookmarkItemType;
+  title: string;
+  url: string | null;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+  updated_at: string;
+}
+
+const BOOKMARK_SELECT_COLUMNS = 'item_id, item_type, title, url, metadata, created_at, updated_at';
+
+const mapBookmarkRow = (row: BookmarkRow): BookmarkRecord => ({
+  itemId: row.item_id,
+  itemType: row.item_type,
+  title: row.title,
+  url: row.url,
+  metadata: row.metadata ?? {},
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+});
+
+const getCurrentUserId = async (): Promise<string | null> => {
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return user?.id ?? null;
+};
+
+const fetchExistingBookmark = async (
+  userId: string,
+  itemId: string,
+  itemType: BookmarkItemType
+): Promise<BookmarkRecord | null> => {
+  const { data, error } = await supabase
+    .from('bookmarks')
+    .select(BOOKMARK_SELECT_COLUMNS)
+    .eq('user_id', userId)
+    .eq('item_id', itemId)
+    .eq('item_type', itemType)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  return mapBookmarkRow(data as BookmarkRow);
+};
+
+class BookmarksService {
+  async getBookmarks(): Promise<BookmarkRecord[]> {
+    const userId = await getCurrentUserId();
+
+    if (!userId) {
+      return [];
+    }
+
+    const { data, error } = await supabase
+      .from('bookmarks')
+      .select(BOOKMARK_SELECT_COLUMNS)
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    return ((data ?? []) as BookmarkRow[]).map(mapBookmarkRow);
+  }
+
+  async addBookmark(input: CreateBookmarkInput): Promise<BookmarkRecord> {
+    const userId = await getCurrentUserId();
+
+    if (!userId) {
+      throw new Error('Not authenticated');
+    }
+
+    const existingBookmark = await fetchExistingBookmark(userId, input.itemId, input.itemType);
+
+    if (existingBookmark) {
+      return existingBookmark;
+    }
+
+    const { data, error } = await supabase
+      .from('bookmarks')
+      .insert({
+        user_id: userId,
+        item_id: input.itemId,
+        item_type: input.itemType,
+        title: input.title,
+        url: input.url ?? null,
+        metadata: input.metadata ?? {},
+      })
+      .select(BOOKMARK_SELECT_COLUMNS)
+      .single();
+
+    if (error) {
+      if (error.code === '23505') {
+        const duplicateBookmark = await fetchExistingBookmark(userId, input.itemId, input.itemType);
+
+        if (duplicateBookmark) {
+          return duplicateBookmark;
+        }
+      }
+
+      throw new Error(error.message);
+    }
+
+    return mapBookmarkRow(data as BookmarkRow);
+  }
+
+  async removeBookmark(itemId: string, itemType: BookmarkItemType): Promise<void> {
+    const userId = await getCurrentUserId();
+
+    if (!userId) {
+      return;
+    }
+
+    const { error } = await supabase
+      .from('bookmarks')
+      .delete()
+      .eq('user_id', userId)
+      .eq('item_id', itemId)
+      .eq('item_type', itemType);
+
+    if (error) {
+      throw new Error(error.message);
+    }
+  }
+}
+
+export const bookmarksService = new BookmarksService();

--- a/src/pages/Bookmarks/Bookmarks.tsx
+++ b/src/pages/Bookmarks/Bookmarks.tsx
@@ -94,8 +94,8 @@ const ListIcon = ({ className }: { className?: string }): JSX.Element => (
 );
 
 const Bookmarks = (): JSX.Element => {
-  const { bookmarkedQuotes } = useBookmarkedQuotes();
-  const { bookmarkedAffirmations } = useBookmarkedAffirmations();
+  const { bookmarkedQuotes, isLoading: areQuotesLoading } = useBookmarkedQuotes();
+  const { bookmarkedAffirmations, isLoading: areAffirmationsLoading } = useBookmarkedAffirmations();
   const { t } = useCommonTranslation();
 
   // State
@@ -119,7 +119,7 @@ const Bookmarks = (): JSX.Element => {
 
   // Filter and sort bookmarks
   const filteredBookmarks = useMemo(() => {
-    let filtered = allBookmarks;
+    let filtered = [...allBookmarks];
 
     // Filter by type
     if (selectedType !== 'all') {
@@ -174,10 +174,12 @@ const Bookmarks = (): JSX.Element => {
   const totalBookmarks = allBookmarks.length;
   const quotesCount = bookmarkedQuotes.length;
   const affirmationsCount = bookmarkedAffirmations.length;
+  const isLoadingBookmarks = areQuotesLoading || areAffirmationsLoading;
 
   // Memoize translated values to prevent infinite re-renders
   const translations = useMemo(
     () => ({
+      loading: t('common.actions.loading') as string,
       title: t('bookmarks.title') as string,
       subtitle: t('bookmarks.subtitle') as string,
       itemCount: t('bookmarks.itemCount', { count: totalBookmarks }) as string,
@@ -381,7 +383,12 @@ const Bookmarks = (): JSX.Element => {
 
       {/* Content */}
       <div className={styles.content}>
-        {filteredBookmarks.length === 0 ? (
+        {isLoadingBookmarks ? (
+          <div className={styles.emptyState}>
+            <BookmarkIcon className={styles.emptyIcon} />
+            <h3 className={styles.emptyTitle}>{translations.loading}</h3>
+          </div>
+        ) : filteredBookmarks.length === 0 ? (
           <div className={styles.emptyState}>
             <BookmarkIcon className={styles.emptyIcon} />
             <h3 className={styles.emptyTitle}>

--- a/src/shared/components/widgets/AffirmationWidget/AffirmationWidget.tsx
+++ b/src/shared/components/widgets/AffirmationWidget/AffirmationWidget.tsx
@@ -200,7 +200,8 @@ const AffirmationWidget = (): JSX.Element => {
   }, []);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [showSuccessToast, setShowSuccessToast] = useState(false);
-  const { addBookmark, removeBookmark, isBookmarked } = useBookmarkedAffirmations();
+  const { addBookmark, removeBookmark, isBookmarked, isBookmarkActionPending } =
+    useBookmarkedAffirmations();
   const [checkedPersonal, setCheckedPersonal] = useState(false);
 
   const nonPersonalCategory: NonPersonalAffirmationCategory | null =
@@ -439,6 +440,35 @@ const AffirmationWidget = (): JSX.Element => {
   const streakLabel = getText(t('widgets.affirmation.daysStreaking'));
   const reminderMeta = reminderSettings.enabled ? reminderSettings.time : '--:--';
   const streakMeta = `${streak?.current_streak || 0}d`;
+  const currentAffirmationId = currentAffirmation?.id;
+  const isCurrentAffirmationBookmarked = currentAffirmationId
+    ? isBookmarked(currentAffirmationId)
+    : false;
+  const isCurrentAffirmationBookmarkPending = currentAffirmationId
+    ? isBookmarkActionPending(currentAffirmationId)
+    : false;
+
+  const handleToggleBookmark = async (): Promise<void> => {
+    if (!currentAffirmation?.id || isCurrentAffirmationBookmarkPending) {
+      return;
+    }
+
+    try {
+      if (isCurrentAffirmationBookmarked) {
+        await removeBookmark(currentAffirmation.id);
+        return;
+      }
+
+      await addBookmark({
+        id: currentAffirmation.id,
+        text: currentAffirmation.text,
+        category: currentAffirmation.category,
+        timestamp: Date.now(),
+      });
+    } catch (error) {
+      console.error('Failed to update affirmation bookmark:', error);
+    }
+  };
 
   return (
     <div
@@ -642,40 +672,30 @@ const AffirmationWidget = (): JSX.Element => {
 
                 <Tooltip
                   content={
-                    currentAffirmation?.id && isBookmarked(currentAffirmation.id)
+                    isCurrentAffirmationBookmarked
                       ? t('widgets.affirmation.removeBookmark')
                       : t('widgets.affirmation.bookmark')
                   }
                 >
                   <button
-                    className={`${styles.voiceButton} ${currentAffirmation?.id && isBookmarked(currentAffirmation.id) ? styles.bookmarked : ''}`}
+                    className={`${styles.voiceButton} ${
+                      isCurrentAffirmationBookmarked ? styles.bookmarked : ''
+                    }`}
                     onClick={() => {
-                      if (currentAffirmation?.id) {
-                        if (isBookmarked(currentAffirmation.id)) {
-                          removeBookmark(currentAffirmation.id);
-                        } else {
-                          addBookmark({
-                            id: currentAffirmation.id,
-                            text: currentAffirmation.text,
-                            category: currentAffirmation.category,
-                            timestamp: Date.now(),
-                          });
-                        }
-                      }
+                      void handleToggleBookmark();
                     }}
                     aria-label={
-                      currentAffirmation?.id && isBookmarked(currentAffirmation.id)
+                      isCurrentAffirmationBookmarked
                         ? (t('widgets.affirmation.removeBookmark') as string)
                         : (t('widgets.affirmation.bookmarkAffirmation') as string)
                     }
-                    disabled={!currentAffirmation?.id}
+                    aria-pressed={isCurrentAffirmationBookmarked}
+                    disabled={!currentAffirmationId || isCurrentAffirmationBookmarkPending}
                   >
                     <span className={styles.controlIconWrap}>
                       <BookmarkIcon
                         className={styles.voiceIcon}
-                        filled={
-                          currentAffirmation?.id ? isBookmarked(currentAffirmation.id) : false
-                        }
+                        filled={isCurrentAffirmationBookmarked}
                       />
                     </span>
                     <span className={styles.controlText}>

--- a/src/shared/components/widgets/QuoteWidget/QuoteWidget.tsx
+++ b/src/shared/components/widgets/QuoteWidget/QuoteWidget.tsx
@@ -14,6 +14,7 @@ import bookmarkAnimation from './icons/bookmark.json';
 import refreshAnimation from './icons/refresh.json';
 import clipboardAnimation from './icons/clipboard.json';
 import likeAnimation from './icons/like.json';
+import { useBookmarkedQuotes } from '@/shared/hooks/useBookmarkedQuotes';
 
 type QuoteTheme = 'success' | 'motivation' | 'leadership' | 'growth' | 'wisdom';
 
@@ -182,7 +183,6 @@ const QuoteWidget = (): JSX.Element => {
   const [isOverflowing, setIsOverflowing] = useState(false);
   const [collapsedHeight, setCollapsedHeight] = useState<number | null>(null);
 
-  const [isBookmarked, setIsBookmarked] = useState(false);
   const [showTooltip, setShowTooltip] = useState(false);
   const [showSuccess, setShowSuccess] = useState<{
     show: boolean;
@@ -232,6 +232,12 @@ const QuoteWidget = (): JSX.Element => {
     error: quotePoolError,
     refetch: refetchQuotePool,
   } = useQuotePool();
+  const {
+    addBookmark,
+    removeBookmark,
+    isBookmarked: isQuoteBookmarked,
+    isBookmarkActionPending,
+  } = useBookmarkedQuotes();
 
   useEffect(() => {
     if (Array.isArray(fetchedQuotes) && fetchedQuotes.length > 0) {
@@ -265,6 +271,13 @@ const QuoteWidget = (): JSX.Element => {
   }, [isNextQuoteBusy, playRefreshAnimation, stopRefreshAnimation]);
 
   const resolvedTheme = quote ? quoteService.determineQuoteTheme(quote.categories) : QUOTE.theme;
+  const activeQuoteText = quote?.text ?? QUOTE.text;
+  const activeQuoteAuthor = quote?.author ?? QUOTE.author;
+  const currentQuoteId = quote?.documentId;
+  const isCurrentQuoteBookmarked = currentQuoteId ? isQuoteBookmarked(currentQuoteId) : false;
+  const isCurrentQuoteBookmarkPending = currentQuoteId
+    ? isBookmarkActionPending(currentQuoteId)
+    : false;
   const themeConfig = THEME_CONFIG[resolvedTheme];
   const themeBackgrounds = BACKGROUND_IMAGES[resolvedTheme] ?? BACKGROUND_IMAGES.success;
   const backgroundIndex = backgroundIndices[resolvedTheme] ?? 0;
@@ -375,25 +388,44 @@ const QuoteWidget = (): JSX.Element => {
     };
   }, [quote?.text, resolvedTheme]);
 
-  const handleBookmark = (e: React.MouseEvent): void => {
+  const handleBookmark = async (e: React.MouseEvent<HTMLButtonElement>): Promise<void> => {
     e.preventDefault();
     e.stopPropagation();
-    playBookmarkAnimation();
-    setIsBookmarked(prev => !prev);
 
-    if (!isBookmarked) {
+    if (!quote?.documentId || isCurrentQuoteBookmarkPending) {
+      return;
+    }
+
+    playBookmarkAnimation();
+
+    try {
+      if (isCurrentQuoteBookmarked) {
+        await removeBookmark(quote.documentId);
+        return;
+      }
+
+      await addBookmark({
+        id: quote.documentId,
+        text: quote.text,
+        author: quote.author,
+        theme: resolvedTheme,
+        timestamp: Date.now(),
+      });
+
       setShowSuccess({
         show: true,
         message: t('widgets.quote.quoteBookmarked'),
         type: 'bookmark',
       });
       setTimeout(() => setShowSuccess(prev => ({ ...prev, show: false })), 2000);
+    } catch (error) {
+      console.error('Failed to update quote bookmark:', error);
     }
   };
 
   const handleShare = (platform: 'facebook' | 'twitter' | 'instagram'): void => {
-    const quote = `"${QUOTE.text}" - ${QUOTE.author}`;
-    const encodedQuote = encodeURIComponent(quote);
+    const shareText = `"${activeQuoteText}" - ${activeQuoteAuthor}`;
+    const encodedQuote = encodeURIComponent(shareText);
 
     const urls = {
       facebook: `https://www.facebook.com/sharer/sharer.php?u=${window.location.href}&quote=${encodedQuote}`,
@@ -402,7 +434,7 @@ const QuoteWidget = (): JSX.Element => {
     };
 
     if (platform === 'instagram') {
-      navigator.clipboard.writeText(quote);
+      navigator.clipboard.writeText(shareText);
       setShowSuccess({
         show: true,
         message: t('widgets.quote.quoteCopied'),
@@ -418,8 +450,8 @@ const QuoteWidget = (): JSX.Element => {
 
   const handleCopyQuote = (): void => {
     playClipboardAnimation();
-    const quote = `"${QUOTE.text}" - ${QUOTE.author}`;
-    navigator.clipboard.writeText(quote);
+    const shareText = `"${activeQuoteText}" - ${activeQuoteAuthor}`;
+    navigator.clipboard.writeText(shareText);
     setShowSuccess({
       show: true,
       message: t('widgets.quote.quoteCopied') as string,
@@ -622,8 +654,12 @@ const QuoteWidget = (): JSX.Element => {
             <div className={styles.bookmarkWrapper}>
               <button
                 type="button"
-                className={`${styles.bookmarkButton} ${isBookmarked ? styles.bookmarked : ''}`}
-                onClick={handleBookmark}
+                className={`${styles.bookmarkButton} ${
+                  isCurrentQuoteBookmarked ? styles.bookmarked : ''
+                }`}
+                onClick={event => {
+                  void handleBookmark(event);
+                }}
                 onMouseEnter={e => {
                   e.stopPropagation();
                   setShowTooltip(true);
@@ -639,10 +675,12 @@ const QuoteWidget = (): JSX.Element => {
                   setShowTooltip(false);
                 }}
                 aria-label={
-                  isBookmarked
+                  isCurrentQuoteBookmarked
                     ? t('widgets.quote.removeBookmark')
                     : t('widgets.quote.bookmarkQuote')
                 }
+                aria-pressed={isCurrentQuoteBookmarked}
+                disabled={!currentQuoteId || isCurrentQuoteBookmarkPending}
                 style={{ position: 'relative', zIndex: 2 }}
               >
                 <Lottie
@@ -662,7 +700,7 @@ const QuoteWidget = (): JSX.Element => {
                     animate={{ opacity: 1, y: 0 }}
                     exit={{ opacity: 0, y: 8 }}
                   >
-                    {isBookmarked
+                    {isCurrentQuoteBookmarked
                       ? t('widgets.quote.removeBookmark')
                       : t('widgets.quote.bookmarkQuote')}
                   </motion.div>

--- a/src/shared/hooks/useBookmarkedAffirmations.ts
+++ b/src/shared/hooks/useBookmarkedAffirmations.ts
@@ -1,7 +1,4 @@
-import { useState } from 'react';
-import { MOCK_AFFIRMATIONS } from '@/utils/mockData/bookmarks';
-
-const STORAGE_KEY = 'bookmarked_affirmations';
+import { useBookmarksByType } from './useBookmarks';
 
 export interface BookmarkedAffirmation {
   id: string;
@@ -12,48 +9,59 @@ export interface BookmarkedAffirmation {
 
 interface UseBookmarkedAffirmationsResult {
   bookmarkedAffirmations: BookmarkedAffirmation[];
-  addBookmark: (affirmation: BookmarkedAffirmation) => void;
-  removeBookmark: (id: string) => void;
+  addBookmark: (affirmation: BookmarkedAffirmation) => Promise<void>;
+  removeBookmark: (id: string) => Promise<void>;
   isBookmarked: (id: string) => boolean;
+  isBookmarkActionPending: (id: string) => boolean;
+  isLoading: boolean;
+  error: Error | null;
 }
 
+const getMetadataString = (metadata: Record<string, unknown>, key: string): string => {
+  const value = metadata[key];
+  return typeof value === 'string' ? value : '';
+};
+
+const toTimestamp = (value: string): number => {
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? Date.now() : parsed;
+};
+
 export const useBookmarkedAffirmations = (): UseBookmarkedAffirmationsResult => {
-  const [bookmarkedAffirmations, setBookmarkedAffirmations] = useState<BookmarkedAffirmation[]>(
-    () => {
-      const stored = localStorage.getItem(STORAGE_KEY);
-      if (stored) {
-        return JSON.parse(stored);
-      }
-      // Initialize with mock data for development
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(MOCK_AFFIRMATIONS));
-      return MOCK_AFFIRMATIONS;
-    }
-  );
-
-  const addBookmark = (affirmation: BookmarkedAffirmation): void => {
-    setBookmarkedAffirmations(prev => {
-      const newBookmarks = [...prev, { ...affirmation, timestamp: Date.now() }];
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(newBookmarks));
-      return newBookmarks;
-    });
-  };
-
-  const removeBookmark = (id: string): void => {
-    setBookmarkedAffirmations(prev => {
-      const newBookmarks = prev.filter(a => a.id !== id);
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(newBookmarks));
-      return newBookmarks;
-    });
-  };
-
-  const isBookmarked = (id: string): boolean => {
-    return bookmarkedAffirmations.some(a => a.id === id);
-  };
-
-  return {
-    bookmarkedAffirmations,
+  const {
+    bookmarks,
     addBookmark,
     removeBookmark,
     isBookmarked,
+    isBookmarkActionPending,
+    isLoading,
+    error,
+  } = useBookmarksByType<BookmarkedAffirmation>({
+    itemType: 'affirmation',
+    fromRecord: bookmark => ({
+      id: bookmark.itemId,
+      text: getMetadataString(bookmark.metadata, 'text') || bookmark.title,
+      category: getMetadataString(bookmark.metadata, 'category') || 'personal',
+      timestamp: toTimestamp(bookmark.createdAt),
+    }),
+    toCreateInput: affirmation => ({
+      itemId: affirmation.id,
+      itemType: 'affirmation',
+      title: affirmation.text,
+      metadata: {
+        text: affirmation.text,
+        category: affirmation.category,
+      },
+    }),
+  });
+
+  return {
+    bookmarkedAffirmations: bookmarks,
+    addBookmark,
+    removeBookmark,
+    isBookmarked,
+    isBookmarkActionPending,
+    isLoading,
+    error,
   };
 };

--- a/src/shared/hooks/useBookmarkedQuotes.ts
+++ b/src/shared/hooks/useBookmarkedQuotes.ts
@@ -1,7 +1,4 @@
-import { useState } from 'react';
-import { MOCK_QUOTES } from '@/utils/mockData/bookmarks';
-
-const STORAGE_KEY = 'bookmarked_quotes';
+import { useBookmarksByType } from './useBookmarks';
 
 export interface BookmarkedQuote {
   id: string;
@@ -13,46 +10,61 @@ export interface BookmarkedQuote {
 
 interface UseBookmarkedQuotesResult {
   bookmarkedQuotes: BookmarkedQuote[];
-  addBookmark: (quote: BookmarkedQuote) => void;
-  removeBookmark: (id: string) => void;
+  addBookmark: (quote: BookmarkedQuote) => Promise<void>;
+  removeBookmark: (id: string) => Promise<void>;
   isBookmarked: (id: string) => boolean;
+  isBookmarkActionPending: (id: string) => boolean;
+  isLoading: boolean;
+  error: Error | null;
 }
 
+const getMetadataString = (metadata: Record<string, unknown>, key: string): string => {
+  const value = metadata[key];
+  return typeof value === 'string' ? value : '';
+};
+
+const toTimestamp = (value: string): number => {
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? Date.now() : parsed;
+};
+
 export const useBookmarkedQuotes = (): UseBookmarkedQuotesResult => {
-  const [bookmarkedQuotes, setBookmarkedQuotes] = useState<BookmarkedQuote[]>(() => {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) {
-      return JSON.parse(stored);
-    }
-    // Initialize with mock data for development
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(MOCK_QUOTES));
-    return MOCK_QUOTES;
-  });
-
-  const addBookmark = (quote: BookmarkedQuote): void => {
-    setBookmarkedQuotes(prev => {
-      const newBookmarks = [...prev, { ...quote, timestamp: Date.now() }];
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(newBookmarks));
-      return newBookmarks;
-    });
-  };
-
-  const removeBookmark = (id: string): void => {
-    setBookmarkedQuotes(prev => {
-      const newBookmarks = prev.filter(q => q.id !== id);
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(newBookmarks));
-      return newBookmarks;
-    });
-  };
-
-  const isBookmarked = (id: string): boolean => {
-    return bookmarkedQuotes.some(q => q.id === id);
-  };
-
-  return {
-    bookmarkedQuotes,
+  const {
+    bookmarks,
     addBookmark,
     removeBookmark,
     isBookmarked,
+    isBookmarkActionPending,
+    isLoading,
+    error,
+  } = useBookmarksByType<BookmarkedQuote>({
+    itemType: 'quote',
+    fromRecord: bookmark => ({
+      id: bookmark.itemId,
+      text: getMetadataString(bookmark.metadata, 'text') || bookmark.title,
+      author: getMetadataString(bookmark.metadata, 'author'),
+      theme: getMetadataString(bookmark.metadata, 'theme') || 'wisdom',
+      timestamp: toTimestamp(bookmark.createdAt),
+    }),
+    toCreateInput: quote => ({
+      itemId: quote.id,
+      itemType: 'quote',
+      title: quote.text,
+      metadata: {
+        text: quote.text,
+        author: quote.author,
+        theme: quote.theme,
+      },
+    }),
+  });
+
+  return {
+    bookmarkedQuotes: bookmarks,
+    addBookmark,
+    removeBookmark,
+    isBookmarked,
+    isBookmarkActionPending,
+    isLoading,
+    error,
   };
 };

--- a/src/shared/hooks/useBookmarks.ts
+++ b/src/shared/hooks/useBookmarks.ts
@@ -1,0 +1,183 @@
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  bookmarksService,
+  type BookmarkItemType,
+  type BookmarkRecord,
+  type CreateBookmarkInput,
+} from '@/core/services/bookmarksService';
+import { useAuth } from './useAuth';
+
+export const bookmarksQueryKey = (userId?: string | null) =>
+  ['bookmarks', userId ?? 'anonymous'] as const;
+
+interface BookmarkAdapter<TBookmark extends { id: string }> {
+  itemType: BookmarkItemType;
+  fromRecord: (record: BookmarkRecord) => TBookmark;
+  toCreateInput: (bookmark: TBookmark) => CreateBookmarkInput;
+}
+
+interface BookmarkMutationContext {
+  previousBookmarks: BookmarkRecord[];
+  bookmarkId: string;
+}
+
+interface UseBookmarksByTypeResult<TBookmark> {
+  bookmarks: TBookmark[];
+  addBookmark: (bookmark: TBookmark) => Promise<void>;
+  removeBookmark: (id: string) => Promise<void>;
+  isBookmarked: (id: string) => boolean;
+  isBookmarkActionPending: (id: string) => boolean;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+const createOptimisticBookmark = (input: CreateBookmarkInput): BookmarkRecord => {
+  const timestamp = new Date().toISOString();
+
+  return {
+    itemId: input.itemId,
+    itemType: input.itemType,
+    title: input.title,
+    url: input.url ?? null,
+    metadata: input.metadata ?? {},
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+};
+
+export const useBookmarksByType = <TBookmark extends { id: string }>({
+  itemType,
+  fromRecord,
+  toCreateInput,
+}: BookmarkAdapter<TBookmark>): UseBookmarksByTypeResult<TBookmark> => {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+  const [pendingIds, setPendingIds] = useState<string[]>([]);
+  const queryKey = bookmarksQueryKey(user?.id);
+
+  const bookmarksQuery = useQuery({
+    queryKey,
+    queryFn: () => bookmarksService.getBookmarks(),
+    enabled: Boolean(user?.id),
+  });
+
+  const bookmarks = (bookmarksQuery.data ?? [])
+    .filter(bookmark => bookmark.itemType === itemType)
+    .map(fromRecord);
+
+  const addBookmarkMutation = useMutation<
+    BookmarkRecord,
+    Error,
+    TBookmark,
+    BookmarkMutationContext
+  >({
+    mutationFn: bookmark => bookmarksService.addBookmark(toCreateInput(bookmark)),
+    onMutate: async bookmark => {
+      const input = toCreateInput(bookmark);
+
+      setPendingIds(previous =>
+        previous.includes(bookmark.id) ? previous : [...previous, bookmark.id]
+      );
+
+      await queryClient.cancelQueries({ queryKey });
+
+      const previousBookmarks = queryClient.getQueryData<BookmarkRecord[]>(queryKey) ?? [];
+      const alreadyExists = previousBookmarks.some(
+        previousBookmark =>
+          previousBookmark.itemId === input.itemId && previousBookmark.itemType === input.itemType
+      );
+
+      if (!alreadyExists) {
+        queryClient.setQueryData<BookmarkRecord[]>(queryKey, [
+          createOptimisticBookmark(input),
+          ...previousBookmarks,
+        ]);
+      }
+
+      return {
+        previousBookmarks,
+        bookmarkId: bookmark.id,
+      };
+    },
+    onError: (_error, _bookmark, context) => {
+      if (context) {
+        queryClient.setQueryData(queryKey, context.previousBookmarks);
+      }
+    },
+    onSuccess: savedBookmark => {
+      queryClient.setQueryData<BookmarkRecord[]>(queryKey, currentBookmarks => {
+        const nextBookmarks = (currentBookmarks ?? []).filter(
+          bookmark =>
+            !(
+              bookmark.itemId === savedBookmark.itemId &&
+              bookmark.itemType === savedBookmark.itemType
+            )
+        );
+
+        return [savedBookmark, ...nextBookmarks];
+      });
+    },
+    onSettled: (_data, _error, _bookmark, context) => {
+      setPendingIds(previous => previous.filter(id => id !== context?.bookmarkId));
+
+      if (user?.id) {
+        void queryClient.invalidateQueries({ queryKey });
+      }
+    },
+  });
+
+  const removeBookmarkMutation = useMutation<void, Error, string, BookmarkMutationContext>({
+    mutationFn: bookmarkId => bookmarksService.removeBookmark(bookmarkId, itemType),
+    onMutate: async bookmarkId => {
+      setPendingIds(previous =>
+        previous.includes(bookmarkId) ? previous : [...previous, bookmarkId]
+      );
+
+      await queryClient.cancelQueries({ queryKey });
+
+      const previousBookmarks = queryClient.getQueryData<BookmarkRecord[]>(queryKey) ?? [];
+
+      queryClient.setQueryData<BookmarkRecord[]>(
+        queryKey,
+        previousBookmarks.filter(
+          bookmark => !(bookmark.itemId === bookmarkId && bookmark.itemType === itemType)
+        )
+      );
+
+      return {
+        previousBookmarks,
+        bookmarkId,
+      };
+    },
+    onError: (_error, _bookmarkId, context) => {
+      if (context) {
+        queryClient.setQueryData(queryKey, context.previousBookmarks);
+      }
+    },
+    onSettled: (_data, _error, _bookmarkId, context) => {
+      setPendingIds(previous => previous.filter(id => id !== context?.bookmarkId));
+
+      if (user?.id) {
+        void queryClient.invalidateQueries({ queryKey });
+      }
+    },
+  });
+
+  return {
+    bookmarks,
+    addBookmark: async bookmark => {
+      await addBookmarkMutation.mutateAsync(bookmark);
+    },
+    removeBookmark: async bookmarkId => {
+      await removeBookmarkMutation.mutateAsync(bookmarkId);
+    },
+    isBookmarked: bookmarkId =>
+      (bookmarksQuery.data ?? []).some(
+        bookmark => bookmark.itemId === bookmarkId && bookmark.itemType === itemType
+      ),
+    isBookmarkActionPending: bookmarkId => pendingIds.includes(bookmarkId),
+    isLoading: bookmarksQuery.isLoading,
+    error: bookmarksQuery.error ?? addBookmarkMutation.error ?? removeBookmarkMutation.error,
+  };
+};


### PR DESCRIPTION
## Summary
- replace localStorage bookmark state with a shared React Query and Supabase-backed flow
- wire QuoteWidget and AffirmationWidget to persist real bookmark toggles
- keep the Bookmarks page synchronized with optimistic updates and loading state

## Testing
- npm run type-check