### PR TITLE
security: harden frontend CSP and headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,19 +54,7 @@
       type="image/webp"
     >
 
-    <!-- Temporarily allow all content during development -->
-    <meta 
-      http-equiv="Content-Security-Policy" 
-      content="
-        default-src * 'unsafe-inline' 'unsafe-eval' data: blob:;
-        worker-src * 'unsafe-inline' 'unsafe-eval' data: blob:;
-        script-src * 'unsafe-inline' 'unsafe-eval' data: blob:;
-        connect-src * 'unsafe-inline' 'unsafe-eval' data: blob:;
-        img-src * data: blob: 'unsafe-inline';
-        frame-src *;
-        style-src * 'unsafe-inline';
-      "
-    >
+    <!-- CSP is delivered via deployment headers (see vercel.json). -->
   </head>
   <body>
     <div id="root"></div>

--- a/scripts/security/check-frontend-guardrails.mjs
+++ b/scripts/security/check-frontend-guardrails.mjs
@@ -14,6 +14,13 @@ const bannedFrontendEnvVars = [
   ['VITE', 'API', 'URL'].join('_'),
 ];
 const bannedLegacyOrigins = ['localhost:1337', 'strapiapp.com'];
+const bannedCspPatterns = [
+  "default-src *",
+  "script-src *",
+  "connect-src *",
+  "frame-src *",
+  "'unsafe-eval'",
+];
 
 function runGitGrep(pattern, pathspec = ['.']) {
   const result = spawnSync('git', ['grep', '-n', '-I', '--', pattern, '--', ...pathspec], {
@@ -96,12 +103,27 @@ function checkNoLegacyStrapiOriginsInFrontendRuntimeConfig() {
   return valid;
 }
 
+function checkIndexHtmlHasNoPermissiveMetaCsp() {
+  const indexHtml = readFileSync(join(process.cwd(), 'index.html'), 'utf8');
+  let valid = true;
+
+  for (const pattern of bannedCspPatterns) {
+    if (indexHtml.includes(pattern)) {
+      console.error(`\n[guardrails] Permissive CSP pattern detected in index.html: ${pattern}`);
+      valid = false;
+    }
+  }
+
+  return valid;
+}
+
 function main() {
   const checks = [
     checkTokenVarIsAbsentInTrackedFiles(),
     checkApiClientHasNoAuthorizationHeader(),
     checkBannedFrontendEnvVars(),
     checkNoLegacyStrapiOriginsInFrontendRuntimeConfig(),
+    checkIndexHtmlHasNoPermissiveMetaCsp(),
   ];
 
   if (checks.every(Boolean)) {

--- a/vercel.json
+++ b/vercel.json
@@ -1,15 +1,16 @@
 {
   "headers": [
     {
-      "source": "/api/(.*)",
+      "source": "/(.*)",
       "headers": [
-        { "key": "Access-Control-Allow-Credentials", "value": "true" },
-        { "key": "Access-Control-Allow-Origin", "value": "*" },
-        { "key": "Access-Control-Allow-Methods", "value": "GET,OPTIONS,PATCH,DELETE,POST,PUT" },
         {
-          "key": "Access-Control-Allow-Headers",
-          "value": "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version, Authorization, Origin"
-        }
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self' https://sdk.scdn.co; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://*.googleapis.com; img-src 'self' data: blob: https://images.unsplash.com https://img.youtube.com https://*.ytimg.com https://*.supabase.co; font-src 'self' data: https://fonts.gstatic.com https://*.gstatic.com https://fonts.googleapis.com https://*.googleapis.com; connect-src 'self' https://user-service-theta.vercel.app https://*.supabase.co wss://*.supabase.co https://accounts.spotify.com https://api.spotify.com https://www.youtube.com https://*.youtube.com; media-src 'self' https://*.youtube.com https://*.supabase.co; frame-src 'self' https://open.spotify.com https://sdk.scdn.co https://www.youtube.com https://youtube.com; worker-src 'self' blob:; form-action 'self'; upgrade-insecure-requests"
+        },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" }
       ]
     }
   ],


### PR DESCRIPTION
## Summary
- remove the permissive meta CSP from the frontend entrypoint
- deliver a restrictive production CSP and security headers via Vercel
- add a guardrail to catch permissive CSP patterns before deploy

## Validation
- npm run security:guardrails
- npm run build
