### PR TITLE
[codex] Fallback to leaf dashboard queries when overview bootstrap fails

### DIFF
--- a/src/features/dashboard/DashboardOverviewProvider.test.tsx
+++ b/src/features/dashboard/DashboardOverviewProvider.test.tsx
@@ -1,0 +1,127 @@
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import dashboardOverviewService from '@/core/services/dashboardOverviewService';
+import { useAuth } from '@/shared/hooks/useAuth';
+import { DashboardOverviewProvider } from './DashboardOverviewProvider';
+import { useDashboardOverview } from './DashboardOverviewContext';
+
+vi.mock('@/shared/hooks/useAuth', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('@/core/services/dashboardOverviewService', () => ({
+  __esModule: true,
+  default: {
+    getOverview: vi.fn(),
+  },
+}));
+
+const mockedUseAuth = vi.mocked(useAuth);
+const mockedDashboardOverviewService = vi.mocked(dashboardOverviewService);
+
+const createWrapper = (): React.FC<{ children: ReactNode }> => {
+  const queryClient = new QueryClient();
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+};
+
+const OverviewProbe = (): JSX.Element => {
+  const dashboardOverview = useDashboardOverview();
+
+  return (
+    <div data-testid="overview-mode">
+      {dashboardOverview === null ? 'fallback' : dashboardOverview.isLoading ? 'loading' : 'managed'}
+    </div>
+  );
+};
+
+describe('DashboardOverviewProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedUseAuth.mockReturnValue({
+      user: { id: 'user-123', email: 'user@example.com' },
+      isLoading: false,
+      isAuthenticated: true,
+      checkAuth: vi.fn(),
+      logout: vi.fn(),
+    });
+  });
+
+  it('falls back to leaf queries when the overview bootstrap fails without cached data', async () => {
+    mockedDashboardOverviewService.getOverview.mockResolvedValue({
+      data: null,
+      error: 'Request failed with status 504',
+    });
+
+    render(
+      <DashboardOverviewProvider>
+        <OverviewProbe />
+      </DashboardOverviewProvider>,
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('overview-mode').textContent).toBe('fallback');
+    });
+  });
+
+  it('keeps the managed overview context when the bootstrap succeeds', async () => {
+    mockedDashboardOverviewService.getOverview.mockResolvedValue({
+      data: {
+        inspiration: {
+          quotes: [],
+          affirmations: [],
+          hasAffirmedToday: false,
+        },
+        lifeWheel: {},
+        mood: {
+          entries: [],
+          weeklyPulse: {
+            window: { start_date: '2026-04-01', end_date: '2026-04-07', days: 7 },
+            coverage: { logged_days: 0, missing_days: 7 },
+            current_week: {
+              average_score: null,
+              average_mood_id: null,
+              days: [],
+            },
+            comparison: {
+              previous_average_score: null,
+              delta_score: null,
+              direction: 'insufficient_data',
+            },
+          },
+          monthlyPulse: {
+            window: { start_date: '2026-03-11', end_date: '2026-04-07', days: 28 },
+            coverage: { logged_days: 0, missing_days: 28 },
+            current_week: {
+              average_score: null,
+              average_mood_id: null,
+              days: [],
+            },
+            comparison: {
+              previous_average_score: null,
+              delta_score: null,
+              direction: 'insufficient_data',
+            },
+          },
+        },
+      },
+      error: null,
+    });
+
+    render(
+      <DashboardOverviewProvider>
+        <OverviewProbe />
+      </DashboardOverviewProvider>,
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('overview-mode').textContent).toBe('managed');
+    });
+  });
+});

--- a/src/features/dashboard/DashboardOverviewProvider.tsx
+++ b/src/features/dashboard/DashboardOverviewProvider.tsx
@@ -33,8 +33,13 @@ export const DashboardOverviewProvider = ({ children }: { children: ReactNode })
     gcTime: 1000 * 60 * 30,
     refetchOnMount: false,
     refetchOnWindowFocus: false,
+    retry: 1,
+    retryDelay: 750,
     meta: AUTH_SCOPED_QUERY_META,
   });
+
+  const shouldUseLeafFallbackQueries =
+    Boolean(userId) && overviewQuery.error instanceof Error && !overviewQuery.data;
 
   const value = useMemo<DashboardOverviewContextValue>(
     () => ({
@@ -46,6 +51,10 @@ export const DashboardOverviewProvider = ({ children }: { children: ReactNode })
     }),
     [authLoading, overviewQuery.data, overviewQuery.error, overviewQuery.isLoading, userId]
   );
+
+  if (shouldUseLeafFallbackQueries) {
+    return <>{children}</>;
+  }
 
   return (
     <DashboardOverviewContext.Provider value={value}>{children}</DashboardOverviewContext.Provider>


### PR DESCRIPTION
## What changed
- made `DashboardOverviewProvider` stop managing the dashboard through the aggregated overview context when that bootstrap fails without data
- configured the aggregated overview query to retry once with a short delay before falling back
- added a focused provider test that covers the fallback path and the successful managed path

## Why
Even after the auth shell resolved, a failed `/api/dashboard/overview` kept the dashboard widgets tied to the aggregated context, which prevented their individual fallback queries from activating. That made a single transient overview failure much more visible than necessary.

## Impact
- the authenticated shell remains usable when the aggregated dashboard bootstrap fails
- widgets can recover via their own leaf queries instead of waiting on a broken overview response
- the new test locks in that fallback behavior

## Validation
- `npm run test -- src/features/dashboard/DashboardOverviewProvider.test.tsx src/core/services/dashboardOverviewService.test.ts`
- `npm run type-check`
- `npm run build`
