### PR TITLE
fix: retry degraded dashboard inspiration widgets

### DIFF
--- a/public/locales/en/dashboard.json
+++ b/public/locales/en/dashboard.json
@@ -129,7 +129,9 @@
       "getNewQuote": "Get new quote",
       "copyQuote": "Copy quote",
       "tryAgain": "Try Again",
-      "failedToLoad": "Failed to load quotes"
+      "failedToLoad": "Failed to load quotes",
+      "syncing": "Syncing your daily quote...",
+      "retrying": "We are still trying to load your daily quote. We will retry shortly."
     },
     "affirmation": {
       "title": "Daily Affirmation",
@@ -138,6 +140,8 @@
       "dailyIntentionLocked": "Daily intention locked in",
       "loadingAffirmations": "Loading affirmations...",
       "failedToLoad": "Failed to load affirmations for this category",
+      "syncing": "Syncing your affirmations...",
+      "retrying": "We are still trying to load your affirmations. We will retry shortly.",
       "tryAgain": "Try Again",
       "create": "Create",
       "edit": "Edit",

--- a/public/locales/pt/dashboard.json
+++ b/public/locales/pt/dashboard.json
@@ -129,7 +129,9 @@
       "getNewQuote": "Buscar nova frase",
       "copyQuote": "Copiar frase",
       "tryAgain": "Tentar novamente",
-      "failedToLoad": "Falha ao carregar as frases"
+      "failedToLoad": "Falha ao carregar as frases",
+      "syncing": "Sincronizando sua frase do dia...",
+      "retrying": "Ainda estamos tentando carregar sua frase do dia. Vamos tentar novamente em instantes."
     },
     "affirmation": {
       "title": "Afirmação do dia",
@@ -138,6 +140,8 @@
       "dailyIntentionLocked": "Intenção do dia registrada",
       "loadingAffirmations": "Carregando afirmações...",
       "failedToLoad": "Falha ao carregar as afirmações desta categoria",
+      "syncing": "Sincronizando suas afirmações...",
+      "retrying": "Ainda estamos tentando carregar suas afirmações. Vamos tentar novamente em instantes.",
       "tryAgain": "Tentar novamente",
       "create": "Criar",
       "edit": "Editar",

--- a/src/core/services/dashboardOverviewService.test.ts
+++ b/src/core/services/dashboardOverviewService.test.ts
@@ -41,4 +41,97 @@ describe('dashboardOverviewService', () => {
       error: 'Malformed dashboard overview response',
     });
   });
+
+  it('accepts degraded inspiration responses', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          inspiration: {
+            quotes: [],
+            affirmations: [],
+            hasAffirmedToday: false,
+            status: 'degraded',
+          },
+          lifeWheel: {},
+          mood: {
+            entries: [],
+            weeklyPulse: {
+              window: { start_date: '2026-04-01', end_date: '2026-04-07', days: 7 },
+              coverage: { logged_days: 0, missing_days: 7 },
+              current_week: {
+                average_score: null,
+                average_mood_id: null,
+                days: [],
+              },
+              comparison: {
+                previous_average_score: null,
+                delta_score: null,
+                direction: 'insufficient_data',
+              },
+            },
+            monthlyPulse: {
+              window: { start_date: '2026-03-11', end_date: '2026-04-07', days: 28 },
+              coverage: { logged_days: 0, missing_days: 28 },
+              current_week: {
+                average_score: null,
+                average_mood_id: null,
+                days: [],
+              },
+              comparison: {
+                previous_average_score: null,
+                delta_score: null,
+                direction: 'insufficient_data',
+              },
+            },
+          },
+        }),
+      })
+    );
+
+    await expect(dashboardOverviewService.getOverview()).resolves.toEqual({
+      data: {
+        inspiration: {
+          quotes: [],
+          affirmations: [],
+          hasAffirmedToday: false,
+          status: 'degraded',
+        },
+        lifeWheel: {},
+        mood: {
+          entries: [],
+          weeklyPulse: {
+            window: { start_date: '2026-04-01', end_date: '2026-04-07', days: 7 },
+            coverage: { logged_days: 0, missing_days: 7 },
+            current_week: {
+              average_score: null,
+              average_mood_id: null,
+              days: [],
+            },
+            comparison: {
+              previous_average_score: null,
+              delta_score: null,
+              direction: 'insufficient_data',
+            },
+          },
+          monthlyPulse: {
+            window: { start_date: '2026-03-11', end_date: '2026-04-07', days: 28 },
+            coverage: { logged_days: 0, missing_days: 28 },
+            current_week: {
+              average_score: null,
+              average_mood_id: null,
+              days: [],
+            },
+            comparison: {
+              previous_average_score: null,
+              delta_score: null,
+              direction: 'insufficient_data',
+            },
+          },
+        },
+      },
+      error: null,
+    });
+  });
 });

--- a/src/core/services/dashboardOverviewService.ts
+++ b/src/core/services/dashboardOverviewService.ts
@@ -12,6 +12,7 @@ export interface DashboardOverviewResponse {
     quotes: Quote[];
     affirmations: Affirmation[];
     hasAffirmedToday: boolean;
+    status: 'ready' | 'degraded';
   };
   lifeWheel: {
     entry?: {
@@ -43,7 +44,8 @@ const isDashboardOverviewResponse = (value: unknown): value is DashboardOverview
     !isRecord(inspiration) ||
     !Array.isArray(inspiration.quotes) ||
     !Array.isArray(inspiration.affirmations) ||
-    typeof inspiration.hasAffirmedToday !== 'boolean'
+    typeof inspiration.hasAffirmedToday !== 'boolean' ||
+    (inspiration.status !== 'ready' && inspiration.status !== 'degraded')
   ) {
     return false;
   }

--- a/src/features/dashboard/DashboardOverviewContext.ts
+++ b/src/features/dashboard/DashboardOverviewContext.ts
@@ -5,6 +5,7 @@ export interface DashboardOverviewContextValue {
   data: DashboardOverviewResponse | null;
   isLoading: boolean;
   error: Error | null;
+  isInspirationDegraded: boolean;
 }
 
 export const DashboardOverviewContext = createContext<DashboardOverviewContextValue | null>(null);

--- a/src/features/dashboard/DashboardOverviewProvider.test.tsx
+++ b/src/features/dashboard/DashboardOverviewProvider.test.tsx
@@ -34,7 +34,13 @@ const OverviewProbe = (): JSX.Element => {
 
   return (
     <div data-testid="overview-mode">
-      {dashboardOverview === null ? 'fallback' : dashboardOverview.isLoading ? 'loading' : 'managed'}
+      {dashboardOverview === null
+        ? 'fallback'
+        : dashboardOverview.isLoading
+          ? 'loading'
+          : dashboardOverview.isInspirationDegraded
+            ? 'managed-degraded'
+            : 'managed'}
     </div>
   );
 };
@@ -76,6 +82,7 @@ describe('DashboardOverviewProvider', () => {
           quotes: [],
           affirmations: [],
           hasAffirmedToday: false,
+          status: 'ready',
         },
         lifeWheel: {},
         mood: {
@@ -122,6 +129,63 @@ describe('DashboardOverviewProvider', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('overview-mode').textContent).toBe('managed');
+    });
+  });
+
+  it('keeps the managed overview context when inspiration is degraded', async () => {
+    mockedDashboardOverviewService.getOverview.mockResolvedValue({
+      data: {
+        inspiration: {
+          quotes: [],
+          affirmations: [],
+          hasAffirmedToday: false,
+          status: 'degraded',
+        },
+        lifeWheel: {},
+        mood: {
+          entries: [],
+          weeklyPulse: {
+            window: { start_date: '2026-04-01', end_date: '2026-04-07', days: 7 },
+            coverage: { logged_days: 0, missing_days: 7 },
+            current_week: {
+              average_score: null,
+              average_mood_id: null,
+              days: [],
+            },
+            comparison: {
+              previous_average_score: null,
+              delta_score: null,
+              direction: 'insufficient_data',
+            },
+          },
+          monthlyPulse: {
+            window: { start_date: '2026-03-11', end_date: '2026-04-07', days: 28 },
+            coverage: { logged_days: 0, missing_days: 28 },
+            current_week: {
+              average_score: null,
+              average_mood_id: null,
+              days: [],
+            },
+            comparison: {
+              previous_average_score: null,
+              delta_score: null,
+              direction: 'insufficient_data',
+            },
+          },
+        },
+      },
+      error: null,
+    });
+
+    render(
+      <DashboardOverviewProvider>
+        <OverviewProbe />
+      </DashboardOverviewProvider>,
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('overview-mode').textContent).toBe('managed-degraded');
     });
   });
 });

--- a/src/features/dashboard/DashboardOverviewProvider.tsx
+++ b/src/features/dashboard/DashboardOverviewProvider.tsx
@@ -48,6 +48,7 @@ export const DashboardOverviewProvider = ({ children }: { children: ReactNode })
         (!userId && authLoading) ||
         (Boolean(userId) && overviewQuery.isLoading && !overviewQuery.data),
       error: overviewQuery.error instanceof Error ? overviewQuery.error : null,
+      isInspirationDegraded: overviewQuery.data?.inspiration.status === 'degraded',
     }),
     [authLoading, overviewQuery.data, overviewQuery.error, overviewQuery.isLoading, userId]
   );

--- a/src/shared/components/widgets/CardsWidget/CardsWidget.tsx
+++ b/src/shared/components/widgets/CardsWidget/CardsWidget.tsx
@@ -213,6 +213,7 @@ const createCardBackground = (accent: string): string => {
 
 const CARD_OUT_DURATION = 600;
 const CELEBRATION_PARTICLES = 12;
+const FALLBACK_RETRY_DELAY_MS = 4000;
 const celebrationPalette = ['#f472b6', '#a855f7', '#38bdf8', '#facc15', '#4ade80', '#f97316'];
 
 const CardsWidget = (): JSX.Element => {
@@ -220,10 +221,14 @@ const CardsWidget = (): JSX.Element => {
   const categoryTheme = useMemo(() => buildCategoryTheme(t), [t]);
   const dashboardOverview = useDashboardOverview();
   const isDashboardOverviewManaged = dashboardOverview !== null;
+  const isDashboardInspirationDegraded = dashboardOverview?.isInspirationDegraded ?? false;
   const dashboardAffirmations = useMemo(
     () => dashboardOverview?.data?.inspiration?.affirmations ?? [],
     [dashboardOverview?.data?.inspiration?.affirmations]
   );
+  const shouldUseFallbackAffirmationDeck =
+    !isDashboardOverviewManaged ||
+    (isDashboardInspirationDegraded && dashboardAffirmations.length === 0);
   const dashboardHasAffirmedToday = dashboardOverview?.data?.inspiration?.hasAffirmedToday ?? false;
   const shouldLoadBookmarks = useIdleActivation({
     minimumDelay: 1500,
@@ -274,7 +279,8 @@ const CardsWidget = (): JSX.Element => {
     data: affirmationDeck,
     isLoading: isDeckLoading,
     error: deckError,
-  } = useDashboardAffirmationDeck({ enabled: !isDashboardOverviewManaged });
+    refetch: refetchAffirmationDeck,
+  } = useDashboardAffirmationDeck({ enabled: shouldUseFallbackAffirmationDeck });
   const [showReminderSettings, setShowReminderSettings] = useState(false);
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [permission, setPermission] = useState<NotificationPermission>('default');
@@ -294,11 +300,16 @@ const CardsWidget = (): JSX.Element => {
   }, []);
 
   useEffect(() => {
-    const activeAffirmationDeck = isDashboardOverviewManaged
-      ? dashboardAffirmations
-      : (affirmationDeck ?? []);
+    const activeAffirmationDeck =
+      isDashboardOverviewManaged && !shouldUseFallbackAffirmationDeck
+        ? dashboardAffirmations
+        : (affirmationDeck ?? []);
 
     if (!activeAffirmationDeck.length) {
+      if (isDashboardOverviewManaged && isDashboardInspirationDegraded) {
+        setCards([]);
+        setError(null);
+      }
       return;
     }
 
@@ -383,13 +394,19 @@ const CardsWidget = (): JSX.Element => {
     affirmationDeck,
     categoryTheme,
     dashboardAffirmations,
+    isDashboardInspirationDegraded,
     isDashboardOverviewManaged,
     personalAffirmation,
+    shouldUseFallbackAffirmationDeck,
     t,
   ]);
 
   useEffect(() => {
     if (isDashboardOverviewManaged) {
+      if (isDashboardInspirationDegraded) {
+        return;
+      }
+
       if (!dashboardOverview?.error) {
         return;
       }
@@ -407,7 +424,41 @@ const CardsWidget = (): JSX.Element => {
     console.error('Failed to load affirmations for CardsWidget:', deckError);
     setCards([]);
     setError(t('widgets.affirmation.failedToLoad') as string);
-  }, [currentLanguage, dashboardOverview?.error, deckError, isDashboardOverviewManaged, t]);
+  }, [
+    currentLanguage,
+    dashboardOverview?.error,
+    deckError,
+    isDashboardInspirationDegraded,
+    isDashboardOverviewManaged,
+    t,
+  ]);
+
+  useEffect(() => {
+    if (!isDashboardOverviewManaged || !isDashboardInspirationDegraded) {
+      return;
+    }
+
+    if (!shouldUseFallbackAffirmationDeck || (affirmationDeck?.length ?? 0) > 0) {
+      return;
+    }
+
+    if (isDeckLoading) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      void refetchAffirmationDeck({ throwOnError: false });
+    }, FALLBACK_RETRY_DELAY_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [
+    affirmationDeck,
+    isDashboardInspirationDegraded,
+    isDashboardOverviewManaged,
+    isDeckLoading,
+    refetchAffirmationDeck,
+    shouldUseFallbackAffirmationDeck,
+  ]);
 
   useEffect(() => {
     setAffirmedTodayOverride(null);
@@ -604,7 +655,15 @@ const CardsWidget = (): JSX.Element => {
 
   const nextIndex = cards.length > 0 ? (currentIndex + 1) % cards.length : -1;
   const activeCardId = cards.length > 0 ? cards[currentIndex]?.id : undefined;
-  const loading = isDashboardOverviewManaged ? dashboardOverview.isLoading : isDeckLoading;
+  const isRetryingDegradedAffirmations =
+    isDashboardOverviewManaged &&
+    isDashboardInspirationDegraded &&
+    cards.length === 0 &&
+    shouldUseFallbackAffirmationDeck;
+  const loading =
+    ((isDashboardOverviewManaged && !shouldUseFallbackAffirmationDeck)
+      ? dashboardOverview.isLoading
+      : isDeckLoading) && cards.length === 0;
   const resolvedHasAffirmedToday =
     affirmedTodayOverride ??
     (isDashboardOverviewManaged ? dashboardHasAffirmedToday : hasAffirmedToday);
@@ -725,6 +784,9 @@ const CardsWidget = (): JSX.Element => {
   const affirmSubLabel = resolvedHasAffirmedToday
     ? (t('widgets.affirmation.dailyIntentionLocked') as string)
     : (t('widgets.cardsWidget.celebratorySubtext') as string);
+  const affirmationStatusMessage = deckError
+    ? (t('widgets.affirmation.retrying') as string)
+    : (t('widgets.affirmation.syncing') as string);
 
   return (
     <section className={styles.container} aria-label={t('widgets.cardsWidget.ariaLabel') as string}>
@@ -747,6 +809,10 @@ const CardsWidget = (): JSX.Element => {
         {loading ? (
           <div className={styles.status} role="status">
             {t('widgets.affirmation.loadingAffirmations') as string}
+          </div>
+        ) : isRetryingDegradedAffirmations ? (
+          <div className={styles.status} role="status" aria-live="polite">
+            {affirmationStatusMessage}
           </div>
         ) : error ? (
           <div className={styles.status} role="alert">

--- a/src/shared/components/widgets/QuoteWidget/QuoteWidget.tsx
+++ b/src/shared/components/widgets/QuoteWidget/QuoteWidget.tsx
@@ -159,13 +159,19 @@ const LoadingSkeleton = (): JSX.Element => (
   </div>
 );
 
+const FALLBACK_RETRY_DELAY_MS = 4000;
+
 const QuoteWidget = (): JSX.Element => {
   const { t } = useDashboardTranslation();
   const { theme } = useTimeBasedTheme();
   const { elementRef, tilt, handleMouseMove, handleMouseLeave } = useTiltEffect(5);
   const dashboardOverview = useDashboardOverview();
   const isDashboardOverviewManaged = dashboardOverview !== null;
+  const isDashboardInspirationDegraded = dashboardOverview?.isInspirationDegraded ?? false;
   const dashboardQuotes = dashboardOverview?.data?.inspiration?.quotes;
+  const shouldUseFallbackQuotePool =
+    !isDashboardOverviewManaged ||
+    (isDashboardInspirationDegraded && (dashboardQuotes?.length ?? 0) === 0);
   const shouldLoadBookmarkState = useIdleActivation({
     minimumDelay: 1500,
     timeout: 2500,
@@ -226,7 +232,7 @@ const QuoteWidget = (): JSX.Element => {
     error: quotePoolError,
     refetch: refetchQuotePool,
   } = useQuotePool({
-    enabled: !isDashboardOverviewManaged,
+    enabled: shouldUseFallbackQuotePool,
   });
   const {
     addBookmark,
@@ -238,7 +244,7 @@ const QuoteWidget = (): JSX.Element => {
   });
 
   useEffect(() => {
-    if (isDashboardOverviewManaged) {
+    if (isDashboardOverviewManaged && !shouldUseFallbackQuotePool) {
       if (!dashboardQuotes) {
         return;
       }
@@ -254,7 +260,34 @@ const QuoteWidget = (): JSX.Element => {
         previousQuotes === fetchedQuotes ? previousQuotes : fetchedQuotes
       );
     }
-  }, [dashboardQuotes, fetchedQuotes, isDashboardOverviewManaged]);
+  }, [dashboardQuotes, fetchedQuotes, isDashboardOverviewManaged, shouldUseFallbackQuotePool]);
+
+  useEffect(() => {
+    if (!isDashboardOverviewManaged || !isDashboardInspirationDegraded) {
+      return;
+    }
+
+    if (!shouldUseFallbackQuotePool || Array.isArray(fetchedQuotes) && fetchedQuotes.length > 0) {
+      return;
+    }
+
+    if (isQuotePoolLoading) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      void refetchQuotePool({ throwOnError: false });
+    }, FALLBACK_RETRY_DELAY_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [
+    fetchedQuotes,
+    isDashboardInspirationDegraded,
+    isDashboardOverviewManaged,
+    isQuotePoolLoading,
+    refetchQuotePool,
+    shouldUseFallbackQuotePool,
+  ]);
 
   useEffect(() => {
     if (!quote && quotePool.length > 0) {
@@ -262,8 +295,15 @@ const QuoteWidget = (): JSX.Element => {
     }
   }, [quote, quotePool]);
 
+  const isRetryingDegradedQuote =
+    isDashboardOverviewManaged &&
+    isDashboardInspirationDegraded &&
+    !quote &&
+    shouldUseFallbackQuotePool;
   const fetchError =
-    isDashboardOverviewManaged && dashboardOverview.error
+    isRetryingDegradedQuote
+      ? null
+      : isDashboardOverviewManaged && dashboardOverview.error
       ? dashboardOverview.error.message
       : isQuotePoolError && quotePoolError
         ? quotePoolError instanceof Error
@@ -272,9 +312,16 @@ const QuoteWidget = (): JSX.Element => {
         : null;
 
   const isInitialLoading =
-    (isDashboardOverviewManaged ? dashboardOverview.isLoading : isQuotePoolLoading) && !quote;
+    (
+      isDashboardOverviewManaged && !shouldUseFallbackQuotePool
+        ? dashboardOverview.isLoading
+        : isQuotePoolLoading
+    ) && !quote;
   const showLoadingSkeleton = isInitialLoading && !fetchError;
   const isNextQuoteBusy = isFetchingNextQuote || isInitialLoading;
+  const quoteStatusMessage = isQuotePoolError
+    ? (t('widgets.quote.retrying') as string)
+    : (t('widgets.quote.syncing') as string);
 
   const resolvedTheme = quote ? quoteService.determineQuoteTheme(quote.categories) : QUOTE.theme;
   const activeQuoteText = quote?.text ?? QUOTE.text;
@@ -777,6 +824,19 @@ const QuoteWidget = (): JSX.Element => {
               <div className={styles.error}>
                 <div className={styles.errorIcon}>⚠️</div>
                 <div className={styles.errorMessage}>{fetchError}</div>
+                <button
+                  className={styles.retryButton}
+                  onClick={() => {
+                    void refetchQuotePool({ throwOnError: false });
+                  }}
+                >
+                  {t('widgets.common.retry')}
+                </button>
+              </div>
+            ) : isRetryingDegradedQuote ? (
+              <div className={styles.error} role="status" aria-live="polite">
+                <div className={styles.errorIcon}>⏳</div>
+                <div className={styles.errorMessage}>{quoteStatusMessage}</div>
                 <button
                   className={styles.retryButton}
                   onClick={() => {


### PR DESCRIPTION
## Summary
- accept the new degraded inspiration status from the dashboard overview payload
- let quote and affirmation widgets fall back to their own queries when overview inspiration is degraded
- show syncing/retrying copy instead of false empty states, with automatic retry loops
- extend provider and service tests for the new contract

## Verification
- `npm run test -- run src/features/dashboard/DashboardOverviewProvider.test.tsx src/core/services/dashboardOverviewService.test.ts`
- `npm run type-check`
- `npm run build`
